### PR TITLE
情報ダッシュボードに機能追加

### DIFF
--- a/app/api/trpc/rss/index.ts
+++ b/app/api/trpc/rss/index.ts
@@ -9,7 +9,9 @@ import {
   getUserArticles,
   getFeedArticles,
   markAsRead,
-  getReadStatuses
+  getReadStatuses,
+  getZennTrendArticles,
+  getQiitaTrendArticles
 } from './articles';
 
 // フィード関連のプロシージャ
@@ -33,6 +35,8 @@ export const rssRouter = router({
   getFeedArticles,
   markAsRead,
   getReadStatuses,
+  getZennTrendArticles,
+  getQiitaTrendArticles,
   
   // フィード関連
   addFeed,

--- a/app/api/trpc/rss/index.ts
+++ b/app/api/trpc/rss/index.ts
@@ -25,6 +25,15 @@ import {
   updateFeed
 } from './feeds';
 
+// 後で読む機能のプロシージャ
+import {
+  addToReadLater,
+  removeFromReadLater,
+  getReadLaterArticles,
+  isInReadLater,
+  cleanupReadLater
+} from './read-later';
+
 /**
  * RSSルーター
  */
@@ -46,4 +55,11 @@ export const rssRouter = router({
   getPublicFeeds,
   updateAllFeeds,
   updateFeed,
+  
+  // 後で読む機能
+  addToReadLater,
+  removeFromReadLater,
+  getReadLaterArticles,
+  isInReadLater,
+  cleanupReadLater,
 });

--- a/app/api/trpc/rss/read-later.ts
+++ b/app/api/trpc/rss/read-later.ts
@@ -1,0 +1,249 @@
+/**
+ * 後で読む機能のプロシージャ
+ */
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { authenticatedProcedure } from './middleware';
+import { formatArticle } from './utils';
+import type { ReadLater, RssArticle, RssFeed, RssReadStatus } from '@prisma/client';
+
+/**
+ * 後で読むリストに記事を追加
+ */
+export const addToReadLater = authenticatedProcedure
+  .input(z.object({ 
+    articleId: z.string() 
+  }))
+  .mutation(async ({ ctx, input }) => {
+    try {
+      const { prisma } = await import('@/prisma/prisma');
+      const userId = ctx.userId;
+      
+      // 既に追加済みかチェック
+      const existing = await prisma.readLater.findUnique({
+        where: {
+          userId_articleId: {
+            userId,
+            articleId: input.articleId
+          }
+        }
+      });
+      
+      if (existing) {
+        return { success: true, message: '既に後で読むリストに追加されています' };
+      }
+      
+      // 記事が存在するかチェック
+      const article = await prisma.rssArticle.findUnique({
+        where: { id: input.articleId }
+      });
+      
+      if (!article) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: '記事が見つかりません'
+        });
+      }
+      
+      // 後で読むリストに追加
+      await prisma.readLater.create({
+        data: {
+          userId,
+          articleId: input.articleId
+        }
+      });
+      
+      return { success: true, message: '後で読むリストに追加しました' };
+    } catch (error) {
+      console.error('後で読むリストへの追加エラー:', error);
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `後で読むリストへの追加に失敗しました: ${(error as Error).message}`
+      });
+    }
+  });
+
+/**
+ * 後で読むリストから記事を削除
+ */
+export const removeFromReadLater = authenticatedProcedure
+  .input(z.object({ 
+    articleId: z.string() 
+  }))
+  .mutation(async ({ ctx, input }) => {
+    try {
+      const { prisma } = await import('@/prisma/prisma');
+      const userId = ctx.userId;
+      
+      // 削除
+      await prisma.readLater.deleteMany({
+        where: {
+          userId,
+          articleId: input.articleId
+        }
+      });
+      
+      return { success: true, message: '後で読むリストから削除しました' };
+    } catch (error) {
+      console.error('後で読むリストからの削除エラー:', error);
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `後で読むリストからの削除に失敗しました: ${(error as Error).message}`
+      });
+    }
+  });
+
+/**
+ * 後で読むリストの記事を取得
+ */
+export const getReadLaterArticles = authenticatedProcedure
+  .input(z.object({ 
+    limit: z.number().min(1).max(100).default(50) 
+  }))
+  .query(async ({ ctx, input }) => {
+    try {
+      const { prisma } = await import('@/prisma/prisma');
+      const userId = ctx.userId;
+      
+      // 後で読むリストを取得
+      const readLaterItems = await prisma.readLater.findMany({
+        where: { userId },
+        orderBy: { addedAt: 'desc' },
+        take: input.limit,
+        include: {
+          article: {
+            include: {
+              feed: true
+            }
+          }
+        }
+      });
+      
+      // 既読状態を取得
+      const articleIds = readLaterItems.map(item => item.articleId);
+      const readStatuses = await prisma.rssReadStatus.findMany({
+        where: {
+          userId,
+          articleId: { in: articleIds }
+        }
+      });
+      
+      const readStatusMap = new Map(readStatuses.map(status => [status.articleId, status]));
+      
+      // 記事情報をフォーマット
+      const articles = readLaterItems.map(item => {
+        const article = item.article;
+        const isRead = !!readStatusMap.get(article.id);
+        
+        return {
+          ...formatArticle(article),
+          feed: {
+            title: article.feed.title,
+            id: article.feed.id
+          },
+          isRead
+        };
+      });
+      
+      return articles;
+    } catch (error) {
+      console.error('後で読むリスト取得エラー:', error);
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `後で読むリストの取得に失敗しました: ${(error as Error).message}`
+      });
+    }
+  });
+
+/**
+ * 記事が後で読むリストに追加されているかチェック
+ */
+export const isInReadLater = authenticatedProcedure
+  .input(z.object({ 
+    articleIds: z.array(z.string())
+  }))
+  .query(async ({ ctx, input }) => {
+    try {
+      const { prisma } = await import('@/prisma/prisma');
+      const userId = ctx.userId;
+      
+      // 後で読むリストに含まれている記事を取得
+      const readLaterItems = await prisma.readLater.findMany({
+        where: {
+          userId,
+          articleId: { in: input.articleIds }
+        },
+        select: {
+          articleId: true
+        }
+      });
+      
+      // 記事IDごとの結果をマップ
+      const result = Object.fromEntries(
+        input.articleIds.map(id => [id, readLaterItems.some(item => item.articleId === id)])
+      );
+      
+      return result;
+    } catch (error) {
+      console.error('後で読むリストチェックエラー:', error);
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `後で読むリストのチェックに失敗しました: ${(error as Error).message}`
+      });
+    }
+  });
+
+/**
+ * 既読になった記事を後で読むリストから自動的に削除
+ */
+export const cleanupReadLater = authenticatedProcedure
+  .mutation(async ({ ctx }) => {
+    try {
+      const { prisma } = await import('@/prisma/prisma');
+      const userId = ctx.userId;
+      
+      // 後で読むリストの記事IDを取得
+      const readLaterItems = await prisma.readLater.findMany({
+        where: { userId },
+        select: { articleId: true }
+      });
+      
+      const articleIds = readLaterItems.map(item => item.articleId);
+      
+      if (articleIds.length === 0) {
+        return { success: true, count: 0 };
+      }
+      
+      // 既読状態の記事を取得
+      const readStatuses = await prisma.rssReadStatus.findMany({
+        where: {
+          userId,
+          articleId: { in: articleIds },
+          isRead: true
+        },
+        select: { articleId: true }
+      });
+      
+      const readArticleIds = readStatuses.map(status => status.articleId);
+      
+      if (readArticleIds.length === 0) {
+        return { success: true, count: 0 };
+      }
+      
+      // 既読になった記事を後で読むリストから削除
+      const { count } = await prisma.readLater.deleteMany({
+        where: {
+          userId,
+          articleId: { in: readArticleIds }
+        }
+      });
+      
+      return { success: true, count };
+    } catch (error) {
+      console.error('後で読むリストのクリーンアップエラー:', error);
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: `後で読むリストのクリーンアップに失敗しました: ${(error as Error).message}`
+      });
+    }
+  });

--- a/app/rss/info/_components/ArticleList.tsx
+++ b/app/rss/info/_components/ArticleList.tsx
@@ -7,6 +7,9 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { trpc } from '../../../trpc-client';
 import { useSession } from 'next-auth/react';
+import { FaLink, FaMarkdown, FaHeading, FaBookmark, FaTimes, FaCircle } from 'react-icons/fa';
+import { toast } from 'react-hot-toast';
+import { useRouter } from 'next/navigation';
 
 interface Article {
   id: string;
@@ -34,10 +37,31 @@ interface ArticleListProps {
 export default function ArticleList({ articles, isZennFeed = false, onArticleRead }: ArticleListProps) {
   const { data: session } = useSession();
   const isLoggedIn = !!session?.user;
+  const router = useRouter();
   const [expandedArticles, setExpandedArticles] = useState<Set<string>>(new Set());
   const [readArticles, setReadArticles] = useState<Set<string>>(
     new Set(articles.filter(article => article.isRead).map(article => article.id))
   );
+  const [showScrapModal, setShowScrapModal] = useState(false);
+  const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+  
+  // スクラップブック一覧を取得
+  const scrapBooksQuery = trpc.scrapBook.getScrapBooks.useQuery(undefined, {
+    enabled: isLoggedIn,
+    staleTime: 1000 * 60 * 5, // 5分間キャッシュ
+  });
+  
+  // スクラップ作成のミューテーション
+  const addScrapMutation = trpc.scrap.addScrap.useMutation({
+    onSuccess: () => {
+      toast.success('スクラップに保存しました');
+      setShowScrapModal(false);
+      setSelectedArticle(null);
+    },
+    onError: (error) => {
+      toast.error(`エラー: ${error.message}`);
+    }
+  });
   
   // 記事を既読にするミューテーション
   const markAsReadMutation = trpc.rss.markAsRead.useMutation({
@@ -82,6 +106,69 @@ export default function ArticleList({ articles, isZennFeed = false, onArticleRea
     markAsReadMutation.mutate({ articleId });
   };
   
+  // 記事を開く際に既読にする関数
+  const openArticle = (article: Article, e: React.MouseEvent) => {
+    e.preventDefault();
+    
+    // ログイン済みの場合のみ既読にする
+    if (isLoggedIn && !readArticles.has(article.id)) {
+      markAsReadMutation.mutate({ articleId: article.id });
+    }
+    
+    // 記事を新しいタブで開く
+    window.open(article.link, '_blank', 'noopener,noreferrer');
+  };
+  
+  // URLをクリップボードにコピーする関数
+  const copyToClipboard = (text: string, type: string) => {
+    navigator.clipboard.writeText(text)
+      .then(() => {
+        toast.success(`${type}をコピーしました`);
+      })
+      .catch((err) => {
+        console.error(`${type}のコピーに失敗しました:`, err);
+        toast.error(`${type}のコピーに失敗しました`);
+      });
+  };
+
+  // Markdownフォーマットでリンクをコピーする関数
+  const copyMarkdownLink = (title: string, url: string) => {
+    const markdownLink = `[${title}](${url})`;
+    copyToClipboard(markdownLink, 'Markdownリンク');
+  };
+
+  // リンクだけをコピーする関数
+  const copyLinkOnly = (url: string) => {
+    copyToClipboard(url, 'リンク');
+  };
+
+  // タイトルだけをコピーする関数
+  const copyTitleOnly = (title: string) => {
+    copyToClipboard(title, 'タイトル');
+  };
+
+  // スクラップモーダルを表示する関数
+  const openScrapModal = (article: Article) => {
+    if (!session || !session.userId) {
+      toast.error('スクラップを保存するにはログインが必要です');
+      return;
+    }
+
+    setSelectedArticle(article);
+    setShowScrapModal(true);
+  };
+
+  // スクラップを保存する関数
+  const saveToScrap = (scrapBookId: string) => {
+    if (!selectedArticle || !session?.userId) return;
+
+    addScrapMutation.mutate({
+      scrapBookId,
+      content: `RSS記事: ${selectedArticle.title}\n${selectedArticle.link}`,
+      categoryId: null
+    });
+  };
+  
   return (
     <div className="space-y-6">
       {articles.map((article) => {
@@ -103,7 +190,7 @@ export default function ArticleList({ articles, isZennFeed = false, onArticleRea
                       target="_blank" 
                       rel="noopener noreferrer"
                       className="block overflow-hidden rounded"
-                      onClick={(e) => isLoggedIn && markAsRead(article.id, e)}
+                      onClick={(e) => openArticle(article, e)}
                     >
                       <div className={`relative ${isZennFeed ? 'aspect-[1.91/1] w-full' : 'h-40 w-full'}`}>
                         {/* 画像URLが有効かどうかを確認 */}
@@ -141,28 +228,22 @@ export default function ArticleList({ articles, isZennFeed = false, onArticleRea
                 {/* 記事情報 */}
                 <div className={article.imageUrl ? "md:w-3/4" : "w-full"}>
                   <div className="flex items-center gap-2 mb-2">
-                    <h3 className={`text-xl font-semibold ${isRead ? 'text-gray-500 dark:text-gray-400' : ''}`}>
+                    <h3 className={`text-xl font-semibold flex items-center ${isRead ? 'text-gray-500 dark:text-gray-400' : ''}`}>
+                      {isLoggedIn && !isRead && (
+                        <span className="text-blue-500 mr-2 flex-shrink-0" title="未読">
+                          <FaCircle size={10} />
+                        </span>
+                      )}
                       <a 
                         href={article.link} 
                         target="_blank" 
                         rel="noopener noreferrer"
                         className={`hover:text-blue-600 dark:hover:text-blue-400 ${isRead ? 'visited:text-gray-500 dark:visited:text-gray-400' : ''}`}
-                        onClick={(e) => isLoggedIn && markAsRead(article.id, e)}
+                        onClick={(e) => openArticle(article, e)}
                       >
                         {article.title}
                       </a>
                     </h3>
-                    {isLoggedIn && (
-                      <span 
-                        className={`text-xs px-2 py-0.5 rounded ${
-                          isRead 
-                            ? 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300' 
-                            : 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200'
-                        }`}
-                      >
-                        {isRead ? '既読' : '未読'}
-                      </span>
-                    )}
                   </div>
                   
                   {article.description && (
@@ -189,17 +270,55 @@ export default function ArticleList({ articles, isZennFeed = false, onArticleRea
                     
                     <button
                       onClick={() => toggleArticle(article.id)}
-                      className="text-blue-600 dark:text-blue-400 hover:underline ml-auto"
+                      className="text-blue-600 dark:text-blue-400 hover:underline"
                     >
                       {isExpanded ? '折りたたむ' : 'もっと見る'}
                     </button>
+                    
+                    {/* コピー・保存ボタン */}
+                    <div className="flex items-center space-x-3 ml-auto">
+                      <button
+                        onClick={() => copyMarkdownLink(article.title, article.link)}
+                        className="text-gray-600 dark:text-gray-300 hover:opacity-80 transition-opacity"
+                        aria-label="Markdownリンクをコピー"
+                        title="Markdownリンクをコピー"
+                      >
+                        <FaMarkdown size={16} />
+                      </button>
+                      <button
+                        onClick={() => copyLinkOnly(article.link)}
+                        className="text-gray-600 dark:text-gray-300 hover:opacity-80 transition-opacity"
+                        aria-label="リンクをコピー"
+                        title="リンクをコピー"
+                      >
+                        <FaLink size={16} />
+                      </button>
+                      <button
+                        onClick={() => copyTitleOnly(article.title)}
+                        className="text-gray-600 dark:text-gray-300 hover:opacity-80 transition-opacity"
+                        aria-label="タイトルをコピー"
+                        title="タイトルをコピー"
+                      >
+                        <FaHeading size={16} />
+                      </button>
+                      {isLoggedIn && (
+                        <button
+                          onClick={() => openScrapModal(article)}
+                          className="text-yellow-500 hover:opacity-80 transition-opacity"
+                          aria-label="スクラップに保存"
+                          title="スクラップに保存"
+                        >
+                          <FaBookmark size={16} />
+                        </button>
+                      )}
+                    </div>
                     
                     <a 
                       href={article.link} 
                       target="_blank" 
                       rel="noopener noreferrer"
                       className="text-blue-600 dark:text-blue-400 hover:underline"
-                      onClick={(e) => isLoggedIn && markAsRead(article.id, e)}
+                      onClick={(e) => openArticle(article, e)}
                     >
                       記事を読む
                     </a>
@@ -220,6 +339,83 @@ export default function ArticleList({ articles, isZennFeed = false, onArticleRea
           </article>
         );
       })}
+      
+      {/* スクラップブック選択モーダル */}
+      {showScrapModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 w-full max-w-md">
+            <div className="flex justify-between items-center mb-4">
+              <h3 className="text-xl font-semibold">スクラップブックを選択</h3>
+              <button 
+                onClick={() => {
+                  setShowScrapModal(false);
+                  setSelectedArticle(null);
+                }}
+                className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              >
+                <FaTimes size={20} />
+              </button>
+            </div>
+            
+            {scrapBooksQuery.isLoading ? (
+              <div className="py-4 text-center">スクラップブックを読み込み中...</div>
+            ) : scrapBooksQuery.isError ? (
+              <div className="py-4 text-center text-red-500">
+                エラーが発生しました: {scrapBooksQuery.error.message}
+              </div>
+            ) : scrapBooksQuery.data?.length === 0 ? (
+              <div className="py-4 text-center">
+                <p className="mb-4">スクラップブックがありません。新しく作成してください。</p>
+                <button
+                  onClick={() => router.push('/scrap/book/new')}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+                >
+                  スクラップブックを作成
+                </button>
+              </div>
+            ) : (
+              <div className="max-h-60 overflow-y-auto">
+                <ul className="space-y-2">
+                  {scrapBooksQuery.data?.map((book) => (
+                    <li key={book.id}>
+                      <button
+                        onClick={() => saveToScrap(book.id)}
+                        className="w-full text-left p-3 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition"
+                        disabled={addScrapMutation.isLoading}
+                      >
+                        <div className="font-medium">{book.title}</div>
+                        {book.description && (
+                          <div className="text-sm text-gray-500 dark:text-gray-400 line-clamp-1">
+                            {book.description}
+                          </div>
+                        )}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            
+            <div className="mt-4 flex justify-end">
+              <button
+                onClick={() => {
+                  setShowScrapModal(false);
+                  setSelectedArticle(null);
+                }}
+                className="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition mr-2"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => router.push('/scrap/book/new')}
+                className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 transition"
+              >
+                新規作成
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/rss/info/_components/ArticleList.tsx
+++ b/app/rss/info/_components/ArticleList.tsx
@@ -112,9 +112,6 @@ export default function ArticleList({ articles, isZennFeed = false, onArticleRea
         icon: '✓',
         duration: 2000
       });
-      
-      // 既読になったら後で読むリストから自動的に削除
-      cleanupReadLaterMutation.mutate();
     },
     onError: (error) => {
       toast.error(`既読にできませんでした: ${error.message}`, {

--- a/app/rss/info/_components/ArticleList.tsx
+++ b/app/rss/info/_components/ArticleList.tsx
@@ -5,6 +5,8 @@
 
 import Image from 'next/image';
 import { useState } from 'react';
+import { trpc } from '../../../trpc-client';
+import { useSession } from 'next-auth/react';
 
 interface Article {
   id: string;
@@ -16,17 +18,43 @@ interface Article {
   imageUrl: string | null;
   timeAgo: string;
   feedId: string;
+  isRead?: boolean;
   feed?: {
     title: string;
+    id: string;
   };
 }
 
 interface ArticleListProps {
   articles: Article[];
+  isZennFeed?: boolean; // Zennのフィードかどうかを示すフラグ
+  onArticleRead?: (articleId: string) => void; // 記事が既読になった時のコールバック
 }
 
-export default function ArticleList({ articles }: ArticleListProps) {
+export default function ArticleList({ articles, isZennFeed = false, onArticleRead }: ArticleListProps) {
+  const { data: session } = useSession();
+  const isLoggedIn = !!session?.user;
   const [expandedArticles, setExpandedArticles] = useState<Set<string>>(new Set());
+  const [readArticles, setReadArticles] = useState<Set<string>>(
+    new Set(articles.filter(article => article.isRead).map(article => article.id))
+  );
+  
+  // 記事を既読にするミューテーション
+  const markAsReadMutation = trpc.rss.markAsRead.useMutation({
+    onSuccess: (_, variables) => {
+      // 成功時に既読状態を更新
+      setReadArticles(prev => {
+        const newSet = new Set(prev);
+        newSet.add(variables.articleId);
+        return newSet;
+      });
+      
+      // 親コンポーネントに通知
+      if (onArticleRead) {
+        onArticleRead(variables.articleId);
+      }
+    }
+  });
   
   // 記事の展開/折りたたみを切り替える
   const toggleArticle = (articleId: string) => {
@@ -41,28 +69,43 @@ export default function ArticleList({ articles }: ArticleListProps) {
     });
   };
   
+  // 記事を既読にする
+  const markAsRead = (articleId: string, e: React.MouseEvent) => {
+    e.preventDefault(); // リンククリックのデフォルト動作を防止
+    
+    if (!isLoggedIn) return; // ログインしていない場合は何もしない
+    
+    // 既に既読の場合は何もしない
+    if (readArticles.has(articleId)) return;
+    
+    // 既読にするAPIを呼び出す
+    markAsReadMutation.mutate({ articleId });
+  };
+  
   return (
     <div className="space-y-6">
       {articles.map((article) => {
         const isExpanded = expandedArticles.has(article.id);
+        const isRead = readArticles.has(article.id) || article.isRead;
         
         return (
           <article 
             key={article.id} 
-            className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden shadow-sm hover:shadow-md transition"
+            className={`border ${isRead ? 'border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50' : 'border-gray-200 dark:border-gray-700'} rounded-lg overflow-hidden shadow-sm hover:shadow-md transition`}
           >
             <div className="p-4">
               <div className="flex flex-col md:flex-row gap-4">
                 {/* 記事画像（あれば表示） */}
                 {article.imageUrl && (
-                  <div className="md:w-1/4 flex-shrink-0">
+                  <div className={`flex-shrink-0 ${isZennFeed ? 'md:w-1/4' : 'md:w-1/4'}`}>
                     <a 
                       href={article.link} 
                       target="_blank" 
                       rel="noopener noreferrer"
                       className="block overflow-hidden rounded"
+                      onClick={(e) => isLoggedIn && markAsRead(article.id, e)}
                     >
-                      <div className="relative h-40 w-full">
+                      <div className={`relative ${isZennFeed ? 'aspect-[1.91/1] w-full' : 'h-40 w-full'}`}>
                         {/* 画像URLが有効かどうかを確認 */}
                         {(() => {
                           try {
@@ -74,7 +117,7 @@ export default function ArticleList({ articles }: ArticleListProps) {
                                 alt={article.title}
                                 fill
                                 sizes="(max-width: 768px) 100vw, 25vw"
-                                className="object-cover"
+                                className={`${isZennFeed ? 'object-contain' : 'object-cover'}`}
                                 onError={(e) => {
                                   // 画像読み込みエラー時に非表示
                                   const target = e.target as HTMLImageElement;
@@ -97,20 +140,34 @@ export default function ArticleList({ articles }: ArticleListProps) {
                 
                 {/* 記事情報 */}
                 <div className={article.imageUrl ? "md:w-3/4" : "w-full"}>
-                  <h3 className="text-xl font-semibold mb-2">
-                    <a 
-                      href={article.link} 
-                      target="_blank" 
-                      rel="noopener noreferrer"
-                      className="hover:text-blue-600 dark:hover:text-blue-400"
-                    >
-                      {article.title}
-                    </a>
-                  </h3>
+                  <div className="flex items-center gap-2 mb-2">
+                    <h3 className={`text-xl font-semibold ${isRead ? 'text-gray-500 dark:text-gray-400' : ''}`}>
+                      <a 
+                        href={article.link} 
+                        target="_blank" 
+                        rel="noopener noreferrer"
+                        className={`hover:text-blue-600 dark:hover:text-blue-400 ${isRead ? 'visited:text-gray-500 dark:visited:text-gray-400' : ''}`}
+                        onClick={(e) => isLoggedIn && markAsRead(article.id, e)}
+                      >
+                        {article.title}
+                      </a>
+                    </h3>
+                    {isLoggedIn && (
+                      <span 
+                        className={`text-xs px-2 py-0.5 rounded ${
+                          isRead 
+                            ? 'bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300' 
+                            : 'bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200'
+                        }`}
+                      >
+                        {isRead ? '既読' : '未読'}
+                      </span>
+                    )}
+                  </div>
                   
                   {article.description && (
                     <div 
-                      className={`text-gray-600 dark:text-gray-300 mb-3 ${isExpanded ? '' : 'line-clamp-3'}`}
+                      className={`text-gray-600 dark:text-gray-300 mb-3 ${isExpanded ? '' : 'line-clamp-3'} ${isRead ? 'opacity-80' : ''}`}
                       dangerouslySetInnerHTML={{ __html: article.description }}
                     />
                   )}
@@ -142,9 +199,20 @@ export default function ArticleList({ articles }: ArticleListProps) {
                       target="_blank" 
                       rel="noopener noreferrer"
                       className="text-blue-600 dark:text-blue-400 hover:underline"
+                      onClick={(e) => isLoggedIn && markAsRead(article.id, e)}
                     >
                       記事を読む
                     </a>
+                    
+                    {isLoggedIn && !isRead && (
+                      <button
+                        onClick={() => markAsReadMutation.mutate({ articleId: article.id })}
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                        disabled={markAsReadMutation.isLoading}
+                      >
+                        既読にする
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>

--- a/app/rss/info/page.tsx
+++ b/app/rss/info/page.tsx
@@ -3,48 +3,136 @@
  */
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { trpc } from '../../trpc-client';
 import ArticleList from './_components/ArticleList';
 import SourceFilter from './_components/SourceFilter';
 
+// タブの種類を定義
+type TabType = 'userFeeds' | 'zennTrend' | 'qiitaTrend';
+// 既読フィルターの種類を定義
+type ReadFilterType = 'all' | 'read' | 'unread';
+
 export default function InfoPage() {
   const { data: session } = useSession();
   const isLoggedIn = !!session?.user;
   
+  // アクティブなタブの状態（ログイン状態に応じてデフォルト値を設定）
+  const [activeTab, setActiveTab] = useState<TabType>('zennTrend');
+  
+  // ログイン状態が変わったらタブを適切に設定
+  useEffect(() => {
+    if (isLoggedIn) {
+      setActiveTab('userFeeds');
+    } else {
+      setActiveTab('zennTrend');
+    }
+  }, [isLoggedIn]);
+  
   // フィルター状態
   const [selectedSources, setSelectedSources] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [readFilter, setReadFilter] = useState<ReadFilterType>('all');
   const [limit, setLimit] = useState(20);
   
   // ログイン状態に応じて適切なクエリを使用
   const articlesQuery = isLoggedIn
-    ? trpc.rss.getUserArticles.useQuery({ limit })
-    : trpc.rss.getPublicArticles.useQuery({ limit });
+    ? trpc.rss.getUserArticles.useQuery({ 
+        limit,
+        readFilter
+      }, {
+        // limitが変更されたときにクエリを再取得
+        keepPreviousData: true
+      })
+    : trpc.rss.getPublicArticles.useQuery({ limit }, {
+        keepPreviousData: true
+      });
+  
+  // Zennトレンド記事の取得
+  const zennTrendQuery = trpc.rss.getZennTrendArticles.useQuery({ 
+    limit,
+    readFilter: isLoggedIn ? readFilter : 'all'
+  }, {
+    keepPreviousData: true
+  });
+  
+  // Qiitaトレンド記事の取得
+  const qiitaTrendQuery = trpc.rss.getQiitaTrendArticles.useQuery({ 
+    limit,
+    readFilter: isLoggedIn ? readFilter : 'all'
+  }, {
+    keepPreviousData: true
+  });
   
   // フィードの取得（ソースフィルター用）
   const feedsQuery = isLoggedIn
     ? trpc.rss.getUserFeeds.useQuery()
     : trpc.rss.getPublicFeeds.useQuery();
   
-  // 記事をフィルタリング
-  const filteredArticles = articlesQuery.data?.filter(article => {
-    // 検索クエリでフィルタリング
-    const matchesSearch = searchQuery === '' || 
-      article.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (article.description && article.description.toLowerCase().includes(searchQuery.toLowerCase()));
+  // Zennフィードのidを取得
+  const zennFeedId = zennTrendQuery.data && zennTrendQuery.data.length > 0
+    ? zennTrendQuery.data[0].feed?.id
+    : undefined;
+  
+  // Qiitaフィードのidを取得
+  const qiitaFeedId = qiitaTrendQuery.data && qiitaTrendQuery.data.length > 0
+    ? qiitaTrendQuery.data[0].feed?.id
+    : undefined;
+  
+  // アクティブなタブに応じた記事データを取得
+  const getActiveArticles = () => {
+    if (activeTab === 'zennTrend') {
+      return zennTrendQuery.data || [];
+    } else if (activeTab === 'qiitaTrend') {
+      return qiitaTrendQuery.data || [];
+    }
     
-    // ソースでフィルタリング
-    const matchesSource = selectedSources.length === 0 || 
-      selectedSources.includes(article.feedId);
-    
-    return matchesSearch && matchesSource;
-  }) || [];
+    // ユーザーフィードタブの場合は通常のフィルタリングを適用
+    return (articlesQuery.data?.filter(article => {
+      // トレンドフィードの記事を除外
+      if ((zennFeedId && article.feedId === zennFeedId) || 
+          (qiitaFeedId && article.feedId === qiitaFeedId)) {
+        return false;
+      }
+      
+      // 検索クエリでフィルタリング
+      const matchesSearch = searchQuery === '' || 
+        article.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        (article.description && article.description.toLowerCase().includes(searchQuery.toLowerCase()));
+      
+      // ソースでフィルタリング
+      const matchesSource = selectedSources.length === 0 || 
+        selectedSources.includes(article.feedId);
+      
+      return matchesSearch && matchesSource;
+    }) || []);
+  };
+  
+  // 現在のタブに応じたローディング状態
+  const isLoading = activeTab === 'userFeeds' 
+    ? articlesQuery.isLoading 
+    : activeTab === 'zennTrend'
+      ? zennTrendQuery.isLoading
+      : qiitaTrendQuery.isLoading;
+  
+  // 現在のタブに応じたエラー状態
+  const error = activeTab === 'userFeeds' 
+    ? articlesQuery.error 
+    : activeTab === 'zennTrend'
+      ? zennTrendQuery.error
+      : qiitaTrendQuery.error;
+  
+  // 現在のタブに応じたisFetchingの状態
+  const isFetching = activeTab === 'userFeeds' 
+    ? articlesQuery.isFetching 
+    : activeTab === 'zennTrend'
+      ? zennTrendQuery.isFetching
+      : qiitaTrendQuery.isFetching;
   
   // もっと読み込む
   const handleLoadMore = () => {
-    setLimit(prev => prev + 20);
+    setLimit(prevLimit => prevLimit + 20);
   };
   
   // 検索クエリの変更
@@ -57,6 +145,66 @@ export default function InfoPage() {
     setSelectedSources(sources);
   };
   
+  // タブの切り替え
+  const handleTabChange = (tab: TabType) => {
+    setActiveTab(tab);
+  };
+  
+  // 既読フィルターの変更
+  const handleReadFilterChange = (filter: ReadFilterType) => {
+    setReadFilter(filter);
+  };
+  
+  // 記事が既読になった時の処理
+  const handleArticleRead = (articleId: string) => {
+    // 既読フィルターが「未読のみ」の場合、該当記事を表示から除外するために再取得
+    if (readFilter === 'unread') {
+      if (activeTab === 'userFeeds') {
+        articlesQuery.refetch();
+      } else if (activeTab === 'zennTrend') {
+        zennTrendQuery.refetch();
+      } else if (activeTab === 'qiitaTrend') {
+        qiitaTrendQuery.refetch();
+      }
+    }
+  };
+  
+  // 表示する記事
+  const filteredArticles = getActiveArticles();
+  
+  // タブに応じたタイトルを取得
+  const getTabTitle = () => {
+    switch (activeTab) {
+      case 'userFeeds':
+        return '最新記事';
+      case 'zennTrend':
+        return 'Zennトレンド記事';
+      case 'qiitaTrend':
+        return 'Qiitaトレンド記事';
+      default:
+        return '記事一覧';
+    }
+  };
+  
+  // タブに応じた空の状態メッセージを取得
+  const getEmptyMessage = () => {
+    switch (activeTab) {
+      case 'userFeeds':
+        return (
+          <>
+            表示できる記事が登録されていません。
+            {isLoggedIn && ' フィードを追加してください。'}
+          </>
+        );
+      case 'zennTrend':
+        return 'Zennのトレンド記事を読み込めませんでした。';
+      case 'qiitaTrend':
+        return 'Qiitaのトレンド記事を読み込めませんでした。';
+      default:
+        return '記事が見つかりませんでした。';
+    }
+  };
+  
   return (
     <div className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-6">情報ダッシュボード</h1>
@@ -66,71 +214,182 @@ export default function InfoPage() {
           収集した記事の一覧です。検索やフィルターを使って必要な情報を見つけることができます。
         </p>
         
-        {/* 検索バー */}
-        <div className="mb-6">
-          <div className="relative">
-            <input
-              type="text"
-              placeholder="記事を検索..."
-              value={searchQuery}
-              onChange={handleSearchChange}
-              className="w-full p-3 pl-10 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-800"
-            />
-            <svg 
-              className="absolute left-3 top-3.5 h-5 w-5 text-gray-400" 
-              fill="none" 
-              stroke="currentColor" 
-              viewBox="0 0 24 24"
-            >
-              <path 
-                strokeLinecap="round" 
-                strokeLinejoin="round" 
-                strokeWidth={2} 
-                d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" 
-              />
-            </svg>
-          </div>
+        {/* タブ切り替え - ログイン中のみユーザーフィードタブを表示 */}
+        <div className="mb-6 border-b border-gray-200 dark:border-gray-700">
+          <ul className="flex flex-wrap -mb-px">
+            {isLoggedIn && (
+              <li className="mr-2">
+                <button
+                  onClick={() => handleTabChange('userFeeds')}
+                  className={`inline-block p-4 ${
+                    activeTab === 'userFeeds'
+                      ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
+                      : 'text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300'
+                  }`}
+                >
+                  ユーザーフィード
+                </button>
+              </li>
+            )}
+            <li className="mr-2">
+              <button
+                onClick={() => handleTabChange('zennTrend')}
+                className={`inline-block p-4 ${
+                  activeTab === 'zennTrend'
+                    ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
+                    : 'text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300'
+                }`}
+              >
+                Zennトレンド
+              </button>
+            </li>
+            <li className="mr-2">
+              <button
+                onClick={() => handleTabChange('qiitaTrend')}
+                className={`inline-block p-4 ${
+                  activeTab === 'qiitaTrend'
+                    ? 'text-blue-600 border-b-2 border-blue-600 dark:text-blue-400 dark:border-blue-400'
+                    : 'text-gray-500 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-300'
+                }`}
+              >
+                Qiitaトレンド
+              </button>
+            </li>
+          </ul>
         </div>
         
-        {/* ソースフィルター */}
-        {!feedsQuery.isLoading && feedsQuery.data && (
-          <SourceFilter 
-            feeds={feedsQuery.data}
-            selectedSources={selectedSources}
-            onChange={handleSourceFilterChange}
-          />
+        {/* フィルターエリア */}
+        <div className="mb-6 flex flex-wrap gap-4">
+          {/* 既読/未読フィルター - ログイン中のみ表示 */}
+          {isLoggedIn && (
+            <div className="flex items-center space-x-2">
+              <span className="text-sm text-gray-600 dark:text-gray-300">表示:</span>
+              <div className="flex border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden">
+                <button
+                  onClick={() => handleReadFilterChange('all')}
+                  className={`px-3 py-1 text-sm ${
+                    readFilter === 'all'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  すべて
+                </button>
+                <button
+                  onClick={() => handleReadFilterChange('unread')}
+                  className={`px-3 py-1 text-sm ${
+                    readFilter === 'unread'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  未読のみ
+                </button>
+                <button
+                  onClick={() => handleReadFilterChange('read')}
+                  className={`px-3 py-1 text-sm ${
+                    readFilter === 'read'
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  既読のみ
+                </button>
+              </div>
+            </div>
+          )}
+          
+          {/* ユーザーフィードタブの場合のみ検索とソースフィルターを表示 */}
+          {activeTab === 'userFeeds' && isLoggedIn && (
+            <>
+              {/* 検索バー */}
+              <div className="flex-grow">
+                <div className="relative">
+                  <input
+                    type="text"
+                    placeholder="記事を検索..."
+                    value={searchQuery}
+                    onChange={handleSearchChange}
+                    className="w-full p-2 pl-10 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-800"
+                  />
+                  <svg 
+                    className="absolute left-3 top-2.5 h-5 w-5 text-gray-400" 
+                    fill="none" 
+                    stroke="currentColor" 
+                    viewBox="0 0 24 24"
+                  >
+                    <path 
+                      strokeLinecap="round" 
+                      strokeLinejoin="round" 
+                      strokeWidth={2} 
+                      d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" 
+                    />
+                  </svg>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+        
+        {/* ソースフィルター - ユーザーフィードタブの場合のみ表示 */}
+        {activeTab === 'userFeeds' && isLoggedIn && !feedsQuery.isLoading && feedsQuery.data && (
+          <div className="mb-6">
+            <SourceFilter 
+              feeds={feedsQuery.data.filter(feed => 
+                (!zennFeedId || feed.id !== zennFeedId) && 
+                (!qiitaFeedId || feed.id !== qiitaFeedId)
+              )}
+              selectedSources={selectedSources}
+              onChange={handleSourceFilterChange}
+            />
+          </div>
         )}
       </div>
       
       {/* 記事一覧 */}
       <div className="mb-8">
-        <h2 className="text-xl font-semibold mb-4">最新記事</h2>
+        <h2 className="text-xl font-semibold mb-4">
+          {getTabTitle()}
+        </h2>
         
-        {articlesQuery.isLoading ? (
+        {isLoading && !isFetching ? (
           <div className="py-4">記事を読み込み中...</div>
-        ) : articlesQuery.isError ? (
+        ) : error ? (
           <div className="py-4 text-red-500">
-            エラーが発生しました: {articlesQuery.error.message}
+            エラーが発生しました: {error.message}
           </div>
         ) : filteredArticles.length === 0 ? (
           <div className="py-4 text-center border border-dashed border-gray-300 dark:border-gray-600 rounded-lg">
             <p className="text-gray-500 dark:text-gray-400 font-medium">
-              表示できる記事が登録されていません。
-              {isLoggedIn && ' フィードを追加してください。'}
+              {getEmptyMessage()}
             </p>
           </div>
         ) : (
           <>
-            <ArticleList articles={filteredArticles} />
+            <ArticleList 
+              articles={filteredArticles} 
+              isZennFeed={activeTab === 'zennTrend' || activeTab === 'qiitaTrend'}
+              onArticleRead={handleArticleRead}
+            />
             
             {/* もっと読み込むボタン */}
             <div className="mt-6 text-center">
               <button
                 onClick={handleLoadMore}
                 className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
-                disabled={articlesQuery.isLoading}
+                disabled={isFetching}
               >
-                もっと読み込む
+                {isFetching ? (
+                  <span className="flex items-center justify-center">
+                    <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                    </svg>
+                    読み込み中...
+                  </span>
+                ) : (
+                  'もっと読み込む'
+                )}
               </button>
             </div>
           </>

--- a/app/rss/read-later/page.tsx
+++ b/app/rss/read-later/page.tsx
@@ -1,0 +1,164 @@
+/**
+ * 後で読むリストページ
+ */
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { trpc } from '../../trpc-client';
+import ArticleList from '../info/_components/ArticleList';
+import { FaClock, FaSync, FaTrash } from 'react-icons/fa';
+import { toast, Toaster } from 'react-hot-toast';
+import Link from 'next/link';
+
+export default function ReadLaterPage() {
+  const { data: session, status } = useSession();
+  const isLoggedIn = !!session?.user;
+  const [isLoading, setIsLoading] = useState(true);
+  
+  // 後で読むリストの記事を取得
+  const readLaterArticlesQuery = trpc.rss.getReadLaterArticles.useQuery(
+    { limit: 100 },
+    {
+      enabled: isLoggedIn,
+      onSuccess: () => {
+        setIsLoading(false);
+      },
+      onError: () => {
+        setIsLoading(false);
+      }
+    }
+  );
+  
+  // 既読になった記事を後で読むリストから自動的に削除するミューテーション
+  const cleanupReadLaterMutation = trpc.rss.cleanupReadLater.useMutation({
+    onSuccess: (result) => {
+      if (result.count > 0) {
+        toast.success(`既読の${result.count}件の記事を削除しました`, {
+          icon: '🧹',
+          duration: 3000
+        });
+        
+        // 記事リストを再取得
+        readLaterArticlesQuery.refetch();
+      } else {
+        toast.success('削除対象の記事はありませんでした', {
+          duration: 2000
+        });
+      }
+    },
+    onError: (error) => {
+      toast.error(`クリーンアップに失敗しました: ${error.message}`, {
+        duration: 3000
+      });
+    }
+  });
+  
+  // 記事が既読になった時のコールバック
+  const handleArticleRead = () => {
+    // 少し遅延させてから再取得（既読状態が反映されるのを待つ）
+    setTimeout(() => {
+      readLaterArticlesQuery.refetch();
+    }, 500);
+  };
+  
+  // クリーンアップを実行
+  const handleCleanup = () => {
+    cleanupReadLaterMutation.mutate();
+  };
+  
+  // ログイン状態に応じたコンテンツを表示
+  if (status === 'loading' || isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+        </div>
+      </div>
+    );
+  }
+  
+  if (!isLoggedIn) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 text-center">
+          <h1 className="text-2xl font-bold mb-4">ログインが必要です</h1>
+          <p className="mb-6">後で読むリストを利用するには、ログインしてください。</p>
+          <Link 
+            href="/api/auth/signin"
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+          >
+            ログイン
+          </Link>
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <Toaster 
+        position="top-right"
+        toastOptions={{
+          style: {
+            background: '#333',
+            color: '#fff',
+            borderRadius: '8px',
+            padding: '16px'
+          },
+        }}
+      />
+      
+      <div className="flex justify-between items-center mb-6">
+        <div className="flex items-center">
+          <FaClock className="text-blue-500 mr-2" size={24} />
+          <h1 className="text-2xl font-bold">後で読むリスト</h1>
+        </div>
+        
+        <div className="flex space-x-2">
+          <button
+            onClick={() => readLaterArticlesQuery.refetch()}
+            className="flex items-center px-3 py-2 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded hover:bg-gray-300 dark:hover:bg-gray-600 transition"
+            disabled={readLaterArticlesQuery.isRefetching}
+          >
+            <FaSync className={`mr-2 ${readLaterArticlesQuery.isRefetching ? 'animate-spin' : ''}`} />
+            更新
+          </button>
+          
+          <button
+            onClick={handleCleanup}
+            className="flex items-center px-3 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition"
+            disabled={cleanupReadLaterMutation.isLoading}
+          >
+            <FaTrash className="mr-2" />
+            既読記事を削除
+          </button>
+        </div>
+      </div>
+      
+      {readLaterArticlesQuery.isError ? (
+        <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded mb-6">
+          エラーが発生しました: {readLaterArticlesQuery.error.message}
+        </div>
+      ) : readLaterArticlesQuery.data?.length === 0 ? (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 text-center">
+          <h2 className="text-xl font-semibold mb-4">後で読む記事がありません</h2>
+          <p className="mb-6">記事一覧から「後で読む」ボタンをクリックして記事を保存できます。</p>
+          <Link 
+            href="/rss/info"
+            className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+          >
+            記事一覧へ
+          </Link>
+        </div>
+      ) : (
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+          <ArticleList 
+            articles={readLaterArticlesQuery.data} 
+            onArticleRead={handleArticleRead}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/types/rss/infrastructure/prisma-repository.ts
+++ b/app/types/rss/infrastructure/prisma-repository.ts
@@ -15,6 +15,13 @@ import {
 } from '../domain';
 import { RssFeedRepository, RssArticleRepository } from '../repository';
 
+// トレンドフィード URL
+const ZENN_FEED_URL = 'https://zenn.dev/feed';
+const QIITA_FEED_URL = 'https://qiita.com/popular-items/feed';
+
+// 除外するトレンドフィードのURLリスト
+const TREND_FEED_URLS = [ZENN_FEED_URL, QIITA_FEED_URL];
+
 // Prismaを使用したRssFeedRepositoryの実装
 export class PrismaRssFeedRepository implements RssFeedRepository {
   async findById(id: string): Promise<Result<RssFeed | null, DomainError>> {
@@ -99,7 +106,11 @@ export class PrismaRssFeedRepository implements RssFeedRepository {
   async findPublicFeeds(): Promise<Result<RssFeed[], DomainError>> {
     try {
       const feeds = await prisma.rssFeed.findMany({
-        where: { feedType: 'PUBLIC' },
+        where: { 
+          feedType: 'PUBLIC',
+          // トレンドフィードを除外
+          url: { notIn: TREND_FEED_URLS }
+        },
         orderBy: { createdAt: 'desc' }
       });
 
@@ -129,7 +140,9 @@ export class PrismaRssFeedRepository implements RssFeedRepository {
           OR: [
             { userId },
             { feedType: 'PUBLIC' }
-          ]
+          ],
+          // トレンドフィードを除外
+          url: { notIn: TREND_FEED_URLS }
         },
         orderBy: { createdAt: 'desc' }
       });
@@ -376,7 +389,9 @@ export class PrismaRssArticleRepository implements RssArticleRepository {
       const articles = await prisma.rssArticle.findMany({
         where: {
           feed: {
-            feedType: 'PUBLIC'
+            feedType: 'PUBLIC',
+            // トレンドフィードを除外
+            url: { notIn: TREND_FEED_URLS }
           }
         },
         orderBy: { publishedAt: 'desc' },
@@ -415,7 +430,9 @@ export class PrismaRssArticleRepository implements RssArticleRepository {
             OR: [
               { userId },
               { feedType: 'PUBLIC' }
-            ]
+            ],
+            // トレンドフィードを除外
+            url: { notIn: TREND_FEED_URLS }
           }
         },
         orderBy: { publishedAt: 'desc' },

--- a/prisma/migrations/20250405144402_add_read_later_model/migration.sql
+++ b/prisma/migrations/20250405144402_add_read_later_model/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE "ReadLater" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "articleId" TEXT NOT NULL,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ReadLater_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ReadLater_userId_idx" ON "ReadLater"("userId");
+
+-- CreateIndex
+CREATE INDEX "ReadLater_articleId_idx" ON "ReadLater"("articleId");
+
+-- CreateIndex
+CREATE INDEX "ReadLater_addedAt_idx" ON "ReadLater"("addedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReadLater_userId_articleId_key" ON "ReadLater"("userId", "articleId");
+
+-- AddForeignKey
+ALTER TABLE "ReadLater" ADD CONSTRAINT "ReadLater_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReadLater" ADD CONSTRAINT "ReadLater_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "RssArticle"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,19 +16,20 @@ generator client {
 }
 
 model User {
-  id           String          @id @default(uuid())
-  googleId     String          @unique
-  email        String          @unique
-  name         String?
-  image        String?
-  createdAt    DateTime        @default(now())
-  updatedAt    DateTime        @updatedAt
-  Todo         Todo[]
-  Scrap        Scrap[]
-  ScrapBook    ScrapBook[]
-  rssFeeds     RssFeed[]       @relation("UserRssFeeds")
+  id            String          @id @default(uuid())
+  googleId      String          @unique
+  email         String          @unique
+  name          String?
+  image         String?
+  createdAt     DateTime        @default(now())
+  updatedAt     DateTime        @updatedAt
+  Todo          Todo[]
+  Scrap         Scrap[]
+  ScrapBook     ScrapBook[]
+  rssFeeds      RssFeed[]       @relation("UserRssFeeds")
   rssReadStatus RssReadStatus[] 
-  role         UserRole        @default(USER)
+  readLater     ReadLater[]     // 後で読む機能の関連付け
+  role          UserRole        @default(USER)
 }
 
 enum UserRole {
@@ -135,6 +136,7 @@ model RssArticle {
   createdAt   DateTime        @default(now())
   updatedAt   DateTime        @updatedAt
   readStatus  RssReadStatus[] 
+  readLater   ReadLater[]     // 後で読む機能の関連付け
 
   @@index([feedId])
   @@index([publishedAt])
@@ -156,6 +158,23 @@ model RssReadStatus {
   @@index([userId])
   @@index([articleId])
   @@index([isRead])
+}
+
+// 後で読む機能のモデル
+model ReadLater {
+  id        String     @id @default(uuid())
+  userId    String
+  user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  articleId String
+  article   RssArticle @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  addedAt   DateTime   @default(now())
+  createdAt DateTime   @default(now())
+  updatedAt DateTime   @updatedAt
+
+  @@unique([userId, articleId])
+  @@index([userId])
+  @@index([articleId])
+  @@index([addedAt])
 }
 
 // 定期実行ジョブのログ


### PR DESCRIPTION
## 概要

ZennとQiitaの記事を取得する機能の追加
サードパーティのAPIはあったが利用しない。
どちらも公式のAtomフィードが存在したのでそれを利用

ほかにも共有や既読の管理、後で読む機能を追加した